### PR TITLE
refactor: auth 페이지에서 로그인/회원가입 로직 수정(#15)

### DIFF
--- a/src/components/auth/StyledAuth.tsx
+++ b/src/components/auth/StyledAuth.tsx
@@ -1,12 +1,15 @@
 import styled from 'styled-components';
 import loginImg from '@/assets/login/login_img.svg';
 import Signup from '@/components/auth/signup/Signup';
-//import { useState } from 'react'
+import { useState } from 'react';
 import Login from '@/components/auth//login/Login';
 
 const StyledAuth = () => {
-  //const [isSignup, setIsSignup] = useState(true);
-  const isSignup = true;
+  const [isSignup, setIsSignup] = useState(false);
+
+  const handleChange = () => {
+    setIsSignup(!isSignup);
+  };
 
   return (
     <S.AuthWrapper>
@@ -15,7 +18,11 @@ const StyledAuth = () => {
           <img src={loginImg} alt="loginImg" />
         </S.AuthImgContainer>
         <S.AuthFormContainer>
-          {isSignup ? <Signup /> : <Login />}
+          {isSignup ? (
+            <Signup onSwitch={handleChange} />
+          ) : (
+            <Login onSwitch={handleChange} />
+          )}
         </S.AuthFormContainer>
       </S.AuthContainer>
     </S.AuthWrapper>

--- a/src/components/auth/login/Login.tsx
+++ b/src/components/auth/login/Login.tsx
@@ -1,7 +1,8 @@
+import type { AuthProps } from '@/types/types';
 import StyledLogin from './StyledLogin';
 
-const Login = () => {
-  return <StyledLogin />;
+const Login = ({ onSwitch }: AuthProps) => {
+  return <StyledLogin onSwitch={onSwitch} />;
 };
 
 export default Login;

--- a/src/components/auth/login/StyledLogin.tsx
+++ b/src/components/auth/login/StyledLogin.tsx
@@ -5,13 +5,15 @@ import { getAuth, signInWithEmailAndPassword } from 'firebase/auth';
 import { Controller, useForm } from 'react-hook-form';
 import { LoginSchema } from '@/schema/schema';
 import { zodResolver } from '@hookform/resolvers/zod';
+import type { AuthProps } from '@/types/types';
+import { useNavigate } from 'react-router-dom';
 
 type LoginType = {
   email: string;
   password: string;
 };
 
-const StyledLogin = () => {
+const StyledLogin = ({ onSwitch }: AuthProps) => {
   const {
     control,
     formState: { errors },
@@ -25,6 +27,8 @@ const StyledLogin = () => {
     },
   });
 
+  const navigate = useNavigate();
+
   const onSubmit = async (data: LoginType) => {
     try {
       const auth = getAuth();
@@ -34,9 +38,14 @@ const StyledLogin = () => {
         data.password
       );
       console.log(login);
+      navigate('/dashboard');
     } catch (error: unknown) {
       console.error('로그인 에러', error);
     }
+  };
+
+  const handleMove = () => {
+    onSwitch();
   };
 
   return (
@@ -56,6 +65,7 @@ const StyledLogin = () => {
                 error={errors.email}
                 name="email"
                 id="email"
+                height="100%"
               />
             )}
           />
@@ -75,6 +85,7 @@ const StyledLogin = () => {
                 error={errors.password}
                 name="password"
                 id="password"
+                height="100%"
               />
             )}
           />
@@ -82,7 +93,7 @@ const StyledLogin = () => {
 
         <S.AuthFormRowItem>
           <p>아이디/비밀번호 찾기</p>
-          <p>회원가입</p>
+          <p onClick={handleMove}>회원가입</p>
         </S.AuthFormRowItem>
         <Button type="submit" height="6vh">
           로그인
@@ -94,11 +105,18 @@ const StyledLogin = () => {
 
 const S = {
   AuthFormWrapper: styled.div`
-    width: 70%;
+    width: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 2.5vh;
+
+    form {
+      width: 60%;
+      display: flex;
+      flex-direction: column;
+      gap: 2.5vh;
+    }
   `,
 
   AuthFormItem: styled.div<{ $hasError?: boolean }>`

--- a/src/components/auth/signup/Signup.tsx
+++ b/src/components/auth/signup/Signup.tsx
@@ -1,7 +1,8 @@
+import type { AuthProps } from '@/types/types';
 import StyledSignup from './StyledSignup';
 
-const Signup = () => {
-  return <StyledSignup />;
+const Signup = ({ onSwitch }: AuthProps) => {
+  return <StyledSignup onSwitch={onSwitch} />;
 };
 
 export default Signup;

--- a/src/components/auth/signup/StyledSignup.tsx
+++ b/src/components/auth/signup/StyledSignup.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { SignupSchema } from '@/schema/schema';
 import { createUserWithEmailAndPassword, getAuth } from 'firebase/auth';
 import { saveToUserDB } from '@/api/api';
+import type { AuthProps } from '@/types/types';
 
 type FormType = {
   email: string;
@@ -15,7 +16,7 @@ type FormType = {
   userType: string;
 };
 
-const StyledSignup = () => {
+const StyledSignup = ({ onSwitch }: AuthProps) => {
   const {
     control,
     handleSubmit,
@@ -53,6 +54,7 @@ const StyledSignup = () => {
       });
 
       alert('회원가입이 완료되었습니다!');
+      onSwitch();
     } catch (error) {
       console.error('회원가입 에러:', error);
     }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,0 +1,3 @@
+export type AuthProps = {
+  onSwitch: () => void;
+};


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 [#15]

## 🔎 작업 내용

- 로그인/회원가입 랜더링 로직 수정
- onSwitch 함수를 "내려"주어 '회원가입' 텍스트를 클릭하거나 회원가입에서 정보를 정상적으로 등록했을때 로그인화면으로 이동하게끔 수정

## 💾 이미지 첨부

- 스크린샷이나 레퍼런스를 추가해주세요

## 🔧 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요
