### PR TITLE
feat: 현재 로그인한 사용자의 정보를 전역으로 관리 (#25)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@hookform/resolvers": "^5.0.1",
+        "@tanstack/react-query": "^5.80.7",
         "@types/node": "^22.15.21",
         "@vitejs/plugin-react": "^4.5.0",
         "chart.js": "^4.4.9",
@@ -4415,6 +4416,32 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.80.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.7.tgz",
+      "integrity": "sha512-s09l5zeUKC8q7DCCCIkVSns8zZrK4ZDT6ryEjxNBFi68G4z2EBobBS7rdOY3r6W1WbUDpc1fe5oY+YO/+2UVUg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.80.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.80.7.tgz",
+      "integrity": "sha512-u2F0VK6+anItoEvB3+rfvTO9GEh2vb00Je05OwlUe/A0lkJBgW1HckiY3f9YZa+jx6IOe4dHPh10dyp9aY3iRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.80.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@hookform/resolvers": "^5.0.1",
+    "@tanstack/react-query": "^5.80.7",
     "@types/node": "^22.15.21",
     "@vitejs/plugin-react": "^4.5.0",
     "chart.js": "^4.4.9",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,31 @@
+import { useUserStore } from '@/hooks/auth/auth';
 import GlobalStyle from './GlobalStyle';
 import { Router } from '@/routes/Router';
 import { AuthProvider } from '@/store/AuthContext';
+import { useEffect } from 'react';
+import { getUserDB, getUserId } from '@/api/api';
 
 function App() {
+  const { updateCache } = useUserStore();
+
+  useEffect(() => {
+    const initUser = async () => {
+      const userId = getUserId();
+      if (userId) {
+        try {
+          const userData = await getUserDB(userId);
+          if (userData) {
+            updateCache(userData);
+          }
+        } catch (error: unknown) {
+          console.error('초기 사용자 정보 로딩 실패:', error);
+        }
+      }
+    };
+
+    initUser();
+  }, [updateCache]);
+
   return (
     <AuthProvider>
       <GlobalStyle />

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,7 +1,7 @@
 import { AuthContext } from '@/constants/context';
 import { database } from '@/firebase-config';
-import { getAuth } from 'firebase/auth';
 import { get, getDatabase, ref, set } from 'firebase/database';
+import Cookies from 'js-cookie';
 import { useContext } from 'react';
 
 export type UserType = {
@@ -46,14 +46,7 @@ export const getUserDB = async (userId: string) => {
 };
 
 export const getUserId = () => {
-  const auth = getAuth();
-  const currentUser = auth.currentUser;
-
-  if (currentUser) {
-    return currentUser.uid;
-  } else {
-    return null;
-  }
+  return Cookies.get('userId') || '';
 };
 
 export const useAuth = () => useContext(AuthContext);

--- a/src/components/common/button/LogoutButton.tsx
+++ b/src/components/common/button/LogoutButton.tsx
@@ -1,3 +1,4 @@
+//import { useUserStore } from '@/hooks/auth/auth';
 import { colors } from '@/styles';
 import Cookies from 'js-cookie';
 import { useNavigate } from 'react-router-dom';
@@ -8,6 +9,7 @@ const LogoutButton = () => {
 
   const handleLogout = () => {
     Cookies.remove('userId');
+    //useUserStore().clearCache();
     navigate('/auth');
   };
 

--- a/src/components/common/nav/StyledNavigation.tsx
+++ b/src/components/common/nav/StyledNavigation.tsx
@@ -3,8 +3,7 @@ import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { ROUTER_PATH } from '@/constants/constansts';
 import LogoutButton from '@/components/common/button/LogoutButton';
-import { getUserDB, getUserId } from '@/api/api';
-import { useState, useEffect } from 'react';
+import { useUserStore } from '@/hooks/auth/auth';
 
 type StyledNavigationProps = {
   currentPath: string;
@@ -12,37 +11,14 @@ type StyledNavigationProps = {
 
 const StyledNavigation = ({ currentPath }: StyledNavigationProps) => {
   const navigate = useNavigate();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [userData, setUserData] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
 
-  const userId = getUserId();
+  const { user, isLoading, isAuthenticated, error } = useUserStore();
+  if (isLoading) return <div>로딩 중...</div>;
+  if (error) return <div>에러: {error.message}</div>;
+  if (!isAuthenticated) return <div>로그인이 필요합니다</div>;
 
-  useEffect(() => {
-    const fetchUserData = async () => {
-      if (userId) {
-        try {
-          const data = await getUserDB(userId);
-          setUserData(data);
-        } catch (error) {
-          console.error('사용자 데이터 가져오기 실패:', error);
-        } finally {
-          setLoading(false);
-        }
-      } else {
-        setLoading(false);
-      }
-    };
-
-    fetchUserData();
-  }, [userId]);
-
-  if (loading) {
-    return <div>Loading...</div>;
-  }
-
-  const type = userData?.userType === 'company' ? '기업회원' : '개인회원';
-  const nickname = userData?.nickname || '사용자';
+  const type = user.userType === 'company' ? '기업회원' : '개인회원';
+  const nickname = user.nickname || '사용자';
 
   const isDashboardActive = currentPath === ROUTER_PATH.DASHBOARD;
   const isMypageActive = currentPath === ROUTER_PATH.MYPAGE;

--- a/src/hooks/auth/auth.ts
+++ b/src/hooks/auth/auth.ts
@@ -1,0 +1,34 @@
+import { getUserDB, getUserId, type UserType } from '@/api/api';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const useUserStore = () => {
+  const queryClient = useQueryClient();
+
+  const userId = getUserId() || '';
+
+  const authUser = useQuery({
+    queryKey: ['user', 'auth', userId],
+    queryFn: () => getUserDB(userId),
+    enabled: !!userId,
+    staleTime: Infinity,
+  });
+
+  return {
+    user: authUser.data,
+    isLoading: authUser.isLoading,
+    isAuthenticated: !!authUser.data,
+    error: authUser.error,
+
+    refetch: () => {
+      queryClient.invalidateQueries({ queryKey: ['user'] });
+    },
+
+    clearCache: () => {
+      queryClient.removeQueries({ queryKey: ['user'] });
+    },
+
+    updateCache: (userData: UserType) => {
+      queryClient.setQueryData(['user', 'auth', userId], userData);
+    },
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,14 @@ import { createRoot } from 'react-dom/client';
 import './styles/css/reset.css';
 import App from './App.tsx';
 import './firebase-config.ts';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
+  <QueryClientProvider client={queryClient}>
+    <StrictMode>
+      <App />
+    </StrictMode>
+  </QueryClientProvider>
 );


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 [#25]

## 🔎 작업 내용

- [x] tasstack query 설치
- [x] 로그인한 사용자 정보 전역으로 관리
- [x] 쿠키을 가지고 서버로 userId를 보내 로그인 상태 유지 

## 💾 이미지 첨부

![image](https://github.com/user-attachments/assets/500278c2-6e84-4062-b81a-c62c0d1c9693)


## 🔧 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요
