### PR TITLE
[Feat] 대시보드 페이지에서 firebase 데이터와 연동 (#29)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+
     <link rel="stylesheet" href="./src/styles/css/reset.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>탄소 배출량 프로그램</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import GlobalStyle from './GlobalStyle';
 import { Router } from '@/routes/Router';
 import { AuthProvider } from '@/store/AuthContext';
 import { useEffect } from 'react';
-import { getUserDB, getUserId } from '@/api/api';
+import { getUserDB, getUserId } from '@/api/auth/api';
 
 function App() {
   const { updateCache } = useUserStore();

--- a/src/api/auth/api.ts
+++ b/src/api/auth/api.ts
@@ -60,3 +60,4 @@ export const getUserId = () => {
 };
 
 export const useAuth = () => useContext(AuthContext);
+

--- a/src/api/dashboard/api.ts
+++ b/src/api/dashboard/api.ts
@@ -1,0 +1,249 @@
+
+import { database } from '@/firebase-config';
+import { get, ref, } from 'firebase/database';
+
+
+export const getCarbonDB = async (address: string) => {
+  const carbonRef = ref(database, `carbon_data/${address}`);
+  const snapshot = await get(carbonRef);
+
+  if (snapshot.exists()) {
+    const userData = snapshot.val();
+    return userData;
+  }
+};
+
+
+export const getAnalyzeCarbonData = async (address: string, year: string, month?: string) => {
+  const carbonData = await getCarbonDB(address);
+  
+  if (!carbonData) return null;
+  
+  const analysis: { [key: string]: any } = {};
+  
+  // 각 부지별 분석
+  Object.entries(carbonData as Record<string, any>).forEach(([bunji, bunjiData]) => {
+    if (bunjiData[year]) {
+      if (month) {
+        // 특정 월 데이터 분석
+        const monthData = bunjiData[year][month];
+        if (monthData && 
+            typeof monthData === 'object' && 
+            'carbon_emission_kgCO2eq' in monthData && 
+            'electricity_usage_kwh' in monthData) {
+          analysis[bunji] = {
+            year,
+            month,
+            carbon_emission: monthData.carbon_emission_kgCO2eq,
+            electricity_usage: monthData.electricity_usage_kwh,
+            // 단일 월 데이터이므로 분석 정보는 동일
+            analysis: {
+              totalCarbon: monthData.carbon_emission_kgCO2eq,
+              totalElectricity: monthData.electricity_usage_kwh,
+              avgCarbon: monthData.carbon_emission_kgCO2eq,
+              avgElectricity: monthData.electricity_usage_kwh,
+              maxCarbon: monthData.carbon_emission_kgCO2eq,
+              minCarbon: monthData.carbon_emission_kgCO2eq,
+              monthCount: 1
+            }
+          };
+        }
+      } else {
+        // 전체 년도 데이터 분석 (월별 요약)
+        const yearData = bunjiData[year];
+        const monthlyValues = Object.values(yearData as Record<string, any>);
+        
+        // 타입 체크 추가
+        const validMonthlyValues = monthlyValues.filter(month => 
+          month && 
+          typeof month === 'object' && 
+          'carbon_emission_kgCO2eq' in month && 
+          'electricity_usage_kwh' in month
+        );
+        
+        if (validMonthlyValues.length === 0) {
+          console.warn(`No valid data for ${bunji} - ${year}`);
+          return;
+        }
+        
+        // 연간 총합 계산
+        const totalCarbon = validMonthlyValues.reduce((sum, month: any) => 
+          sum + (month.carbon_emission_kgCO2eq || 0), 0
+        );
+        
+        const totalElectricity = validMonthlyValues.reduce((sum, month: any) => 
+          sum + (month.electricity_usage_kwh || 0), 0
+        );
+        
+        // 월평균 계산
+        const avgCarbon = totalCarbon / validMonthlyValues.length;
+        const avgElectricity = totalElectricity / validMonthlyValues.length;
+        
+        // 최대/최소값 찾기
+        const carbonValues = validMonthlyValues.map((m: any) => m.carbon_emission_kgCO2eq || 0);
+        const electricityValues = validMonthlyValues.map((m: any) => m.electricity_usage_kwh || 0);
+        const maxCarbon = Math.max(...carbonValues);
+        const minCarbon = Math.min(...carbonValues);
+        const maxElectricity = Math.max(...electricityValues);
+        const minElectricity = Math.min(...electricityValues);
+        
+        // 월별 데이터 구성
+        const monthlyData: { [key: string]: any } = {};
+        Object.entries(yearData as Record<string, any>).forEach(([monthKey, monthValue]) => {
+          if (monthValue && 
+              typeof monthValue === 'object' && 
+              'carbon_emission_kgCO2eq' in monthValue && 
+              'electricity_usage_kwh' in monthValue) {
+            monthlyData[monthKey] = {
+              carbon_emission: monthValue.carbon_emission_kgCO2eq,
+              electricity_usage: monthValue.electricity_usage_kwh
+            };
+          }
+        });
+        
+        analysis[bunji] = {
+          year,
+          monthlyData,
+          analysis: {
+            totalCarbon,
+            totalElectricity,
+            avgCarbon,
+            avgElectricity,
+            maxCarbon,
+            minCarbon,
+            maxElectricity,
+            minElectricity,
+            monthCount: validMonthlyValues.length
+          }
+        };
+      }
+    }
+  });
+  
+  return Object.keys(analysis).length > 0 ? analysis : null;
+};
+
+// 가장 최근 데이터 가져오기 함수
+export const getLatestCarbonData = async (address: string) => {
+  const carbonData = await getCarbonDB(address);
+  
+  if (!carbonData) return null;
+  
+  let latestYear = '';
+  let latestMonth = '';
+  let latestData: any = null;
+  
+  // 모든 부지에서 가장 최근 데이터 찾기
+  Object.entries(carbonData as Record<string, any>).forEach(([bunji, bunjiData]) => {
+    Object.entries(bunjiData as Record<string, any>).forEach(([year, yearData]) => {
+      Object.entries(yearData as Record<string, any>).forEach(([month, monthData]) => {
+        if (monthData && 
+            typeof monthData === 'object' && 
+            'carbon_emission_kgCO2eq' in monthData && 
+            'electricity_usage_kwh' in monthData) {
+          
+          const currentDate = `${year}-${month.padStart(2, '0')}`;
+          const latestDate = latestYear && latestMonth ? `${latestYear}-${latestMonth.padStart(2, '0')}` : '';
+          
+          if (!latestDate || currentDate > latestDate) {
+            latestYear = year;
+            latestMonth = month;
+            latestData = {
+              bunji,
+              year,
+              month,
+              data: monthData
+            };
+          }
+        }
+      });
+    });
+  });
+  
+  return latestData;
+};
+
+// 특정 년도/월 데이터 가져오기 함수
+export const getCarbonDataByDate = async (address: string, year: string, month?: string) => {
+  const carbonData = await getCarbonDB(address);
+  
+  if (!carbonData) return null;
+  
+  const result: { [key: string]: any } = {};
+  
+  // 각 부지별로 해당 년도/월 데이터 수집
+  Object.entries(carbonData as Record<string, any>).forEach(([bunji, bunjiData]) => {
+    if (bunjiData[year]) {
+      if (month) {
+        // 특정 월 데이터
+        const monthData = bunjiData[year][month];
+        if (monthData && 
+            typeof monthData === 'object' && 
+            'carbon_emission_kgCO2eq' in monthData && 
+            'electricity_usage_kwh' in monthData) {
+          result[bunji] = {
+            year,
+            month,
+            carbon_emission: monthData.carbon_emission_kgCO2eq,
+            electricity_usage: monthData.electricity_usage_kwh
+          };
+        }
+      } else {
+        // 전체 년도 데이터 (월별 요약)
+        const yearData = bunjiData[year];
+        const monthlyData: { [key: string]: any } = {};
+        
+        Object.entries(yearData as Record<string, any>).forEach(([monthKey, monthValue]) => {
+          if (monthValue && 
+              typeof monthValue === 'object' && 
+              'carbon_emission_kgCO2eq' in monthValue && 
+              'electricity_usage_kwh' in monthValue) {
+            monthlyData[monthKey] = {
+              carbon_emission: monthValue.carbon_emission_kgCO2eq,
+              electricity_usage: monthValue.electricity_usage_kwh
+            };
+          }
+        });
+        
+        if (Object.keys(monthlyData).length > 0) {
+          result[bunji] = {
+            year,
+            monthlyData
+          };
+        }
+      }
+    }
+  });
+  
+  return Object.keys(result).length > 0 ? result : null;
+};
+
+// 사용 가능한 년도/월 목록 가져오기 함수
+export const getAvailableDates = async (address: string) => {
+  const carbonData = await getCarbonDB(address);
+  
+  if (!carbonData) return null;
+  
+  const availableDates: { [year: string]: string[] } = {};
+  
+  Object.entries(carbonData as Record<string, any>).forEach(([bunji, bunjiData]) => {
+    Object.entries(bunjiData as Record<string, any>).forEach(([year, yearData]) => {
+      if (!availableDates[year]) {
+        availableDates[year] = [];
+      }
+      
+      Object.keys(yearData as Record<string, any>).forEach((month) => {
+        if (!availableDates[year].includes(month)) {
+          availableDates[year].push(month);
+        }
+      });
+    });
+  });
+  
+  // 월을 숫자 순서로 정렬
+  Object.keys(availableDates).forEach(year => {
+    availableDates[year] = availableDates[year].sort((a, b) => parseInt(a) - parseInt(b));
+  });
+  
+  return availableDates;
+};

--- a/src/components/auth/signup/StyledSignup.tsx
+++ b/src/components/auth/signup/StyledSignup.tsx
@@ -5,7 +5,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { SignupSchema } from '@/schema/schema';
 import { createUserWithEmailAndPassword, getAuth } from 'firebase/auth';
-import { saveToUserDB } from '@/api/api';
+import { saveToUserDB } from '@/api/auth/api';
 import type { AuthProps } from '@/types/types';
 import DaumPost, { type AddressObj } from '@/api/kakao/DaumPost';
 import { useState } from 'react';

--- a/src/components/common/nav/StyledNavigation.tsx
+++ b/src/components/common/nav/StyledNavigation.tsx
@@ -69,7 +69,7 @@ const S = {
   NavigationLogo: styled.div`
     width: auto;
     height: auto;
-    background-color: blue;
+
     padding: 10px;
     color: white;
   `,

--- a/src/components/dashboard/CarbonDataViewer.tsx
+++ b/src/components/dashboard/CarbonDataViewer.tsx
@@ -1,0 +1,85 @@
+import { getCarbonDB } from '@/api/dashboard/api';
+import React, { useState, useEffect } from 'react';
+
+export const CarbonDataViewer = () => {
+  const [carbonData, setCarbonData] = useState(null);
+  const [selectedBunji, setSelectedBunji] = useState('');
+  const [selectedYear, setSelectedYear] = useState('');
+  const [monthlyData, setMonthlyData] = useState({});
+
+  const address = '서울특별시_강남구_신사동';
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await getCarbonDB(address);
+      if (data) {
+        setCarbonData(data);
+        
+        // 첫 번째 부지를 기본 선택
+        const firstBunji = Object.keys(data)[0];
+        setSelectedBunji(firstBunji);
+        
+        // 첫 번째 연도를 기본 선택
+        if (data[firstBunji]) {
+          const years = Object.keys(data[firstBunji]).sort((a, b) => parseInt(b) - parseInt(a));
+          const latestYear = years[0]; // 가장 큰 연도 (최근 연도)
+          setSelectedYear(latestYear);
+          setMonthlyData(data[firstBunji][latestYear] || {});
+        }
+      }
+    };
+    
+    if (address) {
+      fetchData();
+    }
+  }, [address]);
+
+  // 부지나 연도 변경 시 월별 데이터 업데이트
+  useEffect(() => {
+    if (carbonData && selectedBunji && selectedYear) {
+      const yearData = carbonData[selectedBunji]?.[selectedYear] || {};
+      setMonthlyData(yearData);
+    }
+  }, [carbonData, selectedBunji, selectedYear]);
+
+  if (!carbonData) return <div>로딩 중...</div>;
+
+  return (
+    <div>
+      <h2>탄소 배출 데이터</h2>
+      
+      {/* 부지 선택 */}
+      <select 
+        value={selectedBunji} 
+        onChange={(e) => setSelectedBunji(e.target.value)}
+      >
+        {Object.keys(carbonData).map(bunji => (
+          <option key={bunji} value={bunji}>{bunji}</option>
+        ))}
+      </select>
+      
+      {/* 연도 선택 */}
+      <select 
+        value={selectedYear} 
+        onChange={(e) => setSelectedYear(e.target.value)}
+      >
+        {carbonData[selectedBunji] && Object.keys(carbonData[selectedBunji]).map(year => (
+          <option key={year} value={year}>{year}</option>
+        ))}
+      </select>
+      
+      {/* 월별 데이터 표시 */}
+      <div>
+        <h3>{selectedYear}년 월별 데이터</h3>
+        {Object.entries(monthlyData).map(([month, data]) => (
+          <div key={month} style={{ margin: '10px 0', padding: '10px', border: '1px solid #ccc' }}>
+            <h4>{month}월</h4>
+            <p>탄소 배출량: {data.carbon_emission_kgCO2eq} kgCO2eq</p>
+            <p>전력 사용량: {data.electricity_usage_kwh} kWh</p>
+            <p>주소: {data.retrieved_full_address}</p>
+            <p>도로명 주소: {data.road_address}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -10,9 +10,11 @@ const Dashboard = () => {
   const [carbonLoading, setCarbonLoading ] = useState(true);
   const [analyzeCarbonData, setAnalyzeCarbonData] = useState<CarbonAnalysisResult>();
   const [analyzeCarbonLoading, setAnalyzeCarbonLoading] = useState(true);
-  const { latestData, selectedData, availableDates, loading } = useCarbonData('서울특별시_강남구_신사동');
+  const {latestData, selectedData, availableDates, loading } = useCarbonData('서울특별시_강남구_신사동');
+  const [barSelectedYear, setBarSelectedYear] = useState("2024");
+  const [LineSelectedYear, setLineSelectedYear] = useState("2024");
   const [selectedYear, setSelectedYear] = useState("2024");
-  const [selectedMonth, setSelectedMonth] = useState("");
+  const [selectedMonth, setSelectedMonth] = useState("01");
 
   {loading || carbonLoading || analyzeCarbonLoading  || <div>Loading...</div>}
 
@@ -50,10 +52,12 @@ const Dashboard = () => {
   };
     fetchCarbonData('서울특별시_강남구_신사동');  
     fetchAnalyzeCarbonData('서울특별시_강남구_신사동',selectedYear,selectedMonth);
-
   },[]);
   //return <CarbonDataViewer/>;
-  return <StyledDashboard carbonData = {carbonData} analyzeCarbonData = {analyzeCarbonData} setSelectedYear = {setSelectedYear} setSelectedMonth = {setSelectedMonth}/>;
+  return <StyledDashboard carbonData = {carbonData} analyzeCarbonData = {analyzeCarbonData} 
+  setSelectedMonth = {setSelectedMonth} setSelectedYear = {setSelectedYear} selectedMonth = {selectedMonth}
+  selectedYear = {selectedYear} setBarSelectedYear = {setBarSelectedYear}  setLineSelectedYear = {setLineSelectedYear}
+  LineSelectedYear={LineSelectedYear} BarSelectedYear = {barSelectedYear}/>;
 };
 
 export default Dashboard;

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1,7 +1,59 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import StyledDashboard from './StyledDashboard';
+import { getAnalyzeCarbonData, getCarbonDB } from '@/api/dashboard/api';
+import { CarbonDataViewer } from './CarbonDataViewer';
+import type { CarbonAnalysisResult } from '@/types/types';
+import { useCarbonData } from '@/hooks/dashboard/dashboard';
 const Dashboard = () => {
-  return <StyledDashboard />;
+
+  const [carbonData, setCarbonData] = useState(null);
+  const [carbonLoading, setCarbonLoading ] = useState(true);
+  const [analyzeCarbonData, setAnalyzeCarbonData] = useState<CarbonAnalysisResult>();
+  const [analyzeCarbonLoading, setAnalyzeCarbonLoading] = useState(true);
+  const { latestData, selectedData, availableDates, loading } = useCarbonData('서울특별시_강남구_신사동');
+  const [selectedYear, setSelectedYear] = useState("2024");
+  const [selectedMonth, setSelectedMonth] = useState("");
+
+  {loading || carbonLoading || analyzeCarbonLoading  || <div>Loading...</div>}
+
+  useEffect(() => {
+    const fetchCarbonData = async (address:string) => {
+      try{
+        setCarbonLoading(true);
+        const data = await getCarbonDB(address);
+        
+        if (data) {
+          setCarbonData(data);
+        }
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setCarbonLoading(false);
+      }
+    }
+    
+    const fetchAnalyzeCarbonData = async (address: string, year: string, month?: string) => {
+    try {
+      setAnalyzeCarbonLoading(true);
+      const data = await getAnalyzeCarbonData(address,year,month);
+      
+      if (data) {
+        setAnalyzeCarbonData(data);
+      } else {
+        console.warn('No analysis data returned');
+      }
+    } catch (error) {
+      console.error('Error analyzing carbon data:', error);
+    } finally {
+      setAnalyzeCarbonLoading(false);
+    }
+  };
+    fetchCarbonData('서울특별시_강남구_신사동');  
+    fetchAnalyzeCarbonData('서울특별시_강남구_신사동',selectedYear,selectedMonth);
+
+  },[]);
+  //return <CarbonDataViewer/>;
+  return <StyledDashboard carbonData = {carbonData} analyzeCarbonData = {analyzeCarbonData} setSelectedYear = {setSelectedYear} setSelectedMonth = {setSelectedMonth}/>;
 };
 
 export default Dashboard;

--- a/src/components/dashboard/EnergyCarbonDataViewer.tsx
+++ b/src/components/dashboard/EnergyCarbonDataViewer.tsx
@@ -3,10 +3,10 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 type CarbonDataViewerProps = {
-  LineSetSelectedYear: (year: string) => void;
-  LineSelectedYear: string;
+  setBarSelectedYear: (year: string) => void;
+  BarSelectedYear: string;
 }
-export const CarbonDataViewer = ({LineSetSelectedYear, LineSelectedYear} : CarbonDataViewerProps) => {
+export const EnergyCarbonDataViewer = ({setBarSelectedYear, BarSelectedYear} : CarbonDataViewerProps) => {
   const [carbonData, setCarbonData] = useState(null);
   const [selectedBunji, setSelectedBunji] = useState("0536_0009");
   //const [selectedYear, setSelectedYear] = useState('');
@@ -27,7 +27,7 @@ export const CarbonDataViewer = ({LineSetSelectedYear, LineSelectedYear} : Carbo
         if (data[firstBunji]) {
           const years = Object.keys(data[firstBunji]).sort((a, b) => parseInt(b) - parseInt(a));
           const latestYear = years[0]; // 가장 큰 연도 (최근 연도)
-          LineSetSelectedYear(latestYear);
+          setBarSelectedYear(latestYear);
           setMonthlyData(data[firstBunji][latestYear] || {});
         }
       }
@@ -40,22 +40,22 @@ export const CarbonDataViewer = ({LineSetSelectedYear, LineSelectedYear} : Carbo
 
   // 부지나 연도 변경 시 월별 데이터 업데이트
   useEffect(() => {
-    if (carbonData && selectedBunji && LineSelectedYear) {
-      const yearData = carbonData[selectedBunji]?.[LineSelectedYear] || {};
+    if (carbonData && selectedBunji && BarSelectedYear) {
+      const yearData = carbonData[selectedBunji]?.[BarSelectedYear] || {};
       setMonthlyData(yearData);
     }
-  }, [carbonData, selectedBunji, LineSelectedYear]);
+  }, [carbonData, selectedBunji, BarSelectedYear]);
 
   if (!carbonData) return <div>로딩 중...</div>;
 
   return (
     <div>
       <S.ViewerWrapper>
-      <h2>탄소 배출 데이터(년도)</h2>
+      <h2>에너지 사용 데이터(년도)</h2>
       {/* 연도 선택 */}
       <select 
-        value={LineSelectedYear} 
-        onChange={(e) => LineSetSelectedYear(e.target.value)}
+        value={BarSelectedYear} 
+        onChange={(e) => setBarSelectedYear(e.target.value)}
       >
         {carbonData[selectedBunji] && Object.keys(carbonData[selectedBunji]).map(year => (
           <option key={year} value={year}>{year}</option>
@@ -72,6 +72,4 @@ const S = {
     flex-direction: row;
     gap: 1%;
   `
-
-
 }

--- a/src/components/dashboard/StyledDashboard.tsx
+++ b/src/components/dashboard/StyledDashboard.tsx
@@ -13,26 +13,29 @@ import BarLineChart from './chart/BarLineChart';
 import CircleChart from './chart/CircleChart';
 import LineChart from './chart/LineChart';
 import type { CarbonAnalysisResult } from '@/types/types';
-import { useState } from 'react';
+import { CarbonDataViewer } from './CarbonDataViewer';
+import { EnergyCarbonDataViewer } from './EnergyCarbonDataViewer';
 
-type StyledDashboardProps = {
-  carbonData: any; // 실제 type으로 변경 필요
-  analyzeCarbonData: CarbonAnalysisResult | undefined;
-  setSelectedYear: React.Dispatch<React.SetStateAction<string>>;
-  setSelectedMonth: React.Dispatch<React.SetStateAction<string>>;
+type StyledDashboardProps = {   
+  carbonData: any; // 실제 type으로 변경 필요   
+  analyzeCarbonData: CarbonAnalysisResult | undefined;   
+  selectedYear: string;   
+  selectedMonth: string;
+  LineSelectedYear: string;
+  BarSelectedYear: string;
+  setSelectedMonth: React.Dispatch<React.SetStateAction<string>>; 
+  setSelectedYear: React.Dispatch<React.SetStateAction<string>>; 
+  setBarSelectedYear: React.Dispatch<React.SetStateAction<string>>;   
+  setLineSelectedYear: React.Dispatch<React.SetStateAction<string>>; 
 }
 
 
-const StyledDashboard = ({ carbonData, analyzeCarbonData, setSelectedYear, setSelectedMonth }:StyledDashboardProps) => {
-
-  
-  const [selectedYear, setSelectedYedr] = useState('2024');
+const StyledDashboard = ({ carbonData, analyzeCarbonData, selectedYear, 
+  selectedMonth, LineSelectedYear, BarSelectedYear, setSelectedMonth, setBarSelectedYear, setSelectedYear, setLineSelectedYear
+ }:StyledDashboardProps) => {
   const locationKey = "0536_0009";
-  const yearKey = "2024";
-  const cData = carbonData?.[locationKey]?.[yearKey];
   const aData = analyzeCarbonData?.[locationKey]?.analysis;
-  console.log('carbonData : ', carbonData)
-  console.log('analyzeCarbonData : ',analyzeCarbonData)
+  //const [selectedBunji, setSelectedBunji] = useState("0536_0009");
   
   return (
     <S.DashboardWrapper>
@@ -46,7 +49,7 @@ const StyledDashboard = ({ carbonData, analyzeCarbonData, setSelectedYear, setSe
               {selectedYear}
             </S.Row>
           </S.HeaderItemTitle>
-          <S.HeaderItemNumber>{Math.floor(aData?.totalElectricity ?? 0).toLocaleString()}Wh</S.HeaderItemNumber>
+          <S.HeaderItemNumber>{Math.floor(aData?.totalElectricity ?? 0).toLocaleString()}<span>Wh</span></S.HeaderItemNumber>
         </S.DashboardHeaderItem>
         <S.DashboardHeaderItem>
           <S.HeaderItemTitle>
@@ -54,10 +57,10 @@ const StyledDashboard = ({ carbonData, analyzeCarbonData, setSelectedYear, setSe
               <img src={secondImg} alt="secondImg" />
               월 평균 전기 사용량
               <br />
-              Utillization
+              {selectedMonth}월
             </S.Row>
           </S.HeaderItemTitle>
-          <S.HeaderItemNumber>{Math.floor(aData?.avgElectricity ?? 0).toLocaleString()}Wh</S.HeaderItemNumber>
+          <S.HeaderItemNumber>{Math.floor(aData?.avgElectricity ?? 0).toLocaleString()}<span>Wh</span></S.HeaderItemNumber>
         </S.DashboardHeaderItem>
         <S.DashboardHeaderItem>
           <S.HeaderItemTitle>
@@ -68,7 +71,7 @@ const StyledDashboard = ({ carbonData, analyzeCarbonData, setSelectedYear, setSe
               {selectedYear}
             </S.Row>
           </S.HeaderItemTitle>
-          <S.HeaderItemNumber>{Math.floor(aData?.totalCarbon ?? 0).toLocaleString()}</S.HeaderItemNumber>
+          <S.HeaderItemNumber>{Math.floor(aData?.totalCarbon ?? 0).toLocaleString()}<span>tCO2eq</span></S.HeaderItemNumber>
         </S.DashboardHeaderItem>
         <S.DashboardHeaderItem>
           <S.HeaderItemTitle>
@@ -76,16 +79,18 @@ const StyledDashboard = ({ carbonData, analyzeCarbonData, setSelectedYear, setSe
               <img src={fourthImg} alt="fourthImg" />
               월 평균 탄소 배출량
               <br />
+              {selectedMonth}월
             </S.Row>
           </S.HeaderItemTitle>
           <S.HeaderItemNumber>
             <S.Row>
               <p>{Math.floor(aData?.avgCarbon ?? 0).toLocaleString()}</p>
-              <span>
+              <span>tCO2eq</span>
+              {/* <span>
                 metric tons
                 <br />
                 CO2/year
-              </span>
+              </span> */}
             </S.Row>
           </S.HeaderItemNumber>
         </S.DashboardHeaderItem>
@@ -101,11 +106,12 @@ const StyledDashboard = ({ carbonData, analyzeCarbonData, setSelectedYear, setSe
           <S.HeaderItemNumber>
             <S.Row>
               <p>{Math.floor(aData?.maxCarbon ?? 0).toLocaleString()}</p>
-              <span>
+              <span>tCO2eq</span>
+              {/* <span>
                 metric tons
                 <br />
                 CO2/year
-              </span>
+              </span> */}
             </S.Row>
           </S.HeaderItemNumber>
         </S.DashboardHeaderItem>
@@ -118,31 +124,35 @@ const StyledDashboard = ({ carbonData, analyzeCarbonData, setSelectedYear, setSe
               탄소 배출량
             </S.Row>
           </S.HeaderItemTitle>
-          <S.HeaderItemNumber>{Math.floor(aData?.minCarbon ?? 0).toLocaleString()}</S.HeaderItemNumber>
+          <S.HeaderItemNumber>{Math.floor(aData?.minCarbon ?? 0).toLocaleString()}<span>tCO2eq</span></S.HeaderItemNumber>
         </S.DashboardHeaderItem>
       </S.DashboardHeader>
       <S.DashboardMiddle>
         <S.MiddleTitle>
-          <div style={{ display: 'flex', gap: '0.7vw' }}>
+            <S.Row>
             <img src={home} alt="home" />
-            Energy Usage
-          </div>
+            <p>에너지 사용</p>
+            </S.Row>
+            <h4><EnergyCarbonDataViewer setBarSelectedYear={setBarSelectedYear} BarSelectedYear={BarSelectedYear}/></h4>
           <div style={{ display: 'flex', gap: '0.7vw' }}>
             <img src={calendar} alt="calendar" />
-            Daily Energy Cost
+            우리 동네에서 내 탄소 점유율
           </div>
         </S.MiddleTitle>
         <S.Row>
-          <BarLineChart />
+          <BarLineChart carbonData = {carbonData} BarSelectedYear = {BarSelectedYear}/>
           <CircleChart />
         </S.Row>
       </S.DashboardMiddle>
       <S.DashboardBottom>
         <S.BottomTitle>
+          <div>
           <img src={co2} alt="co2" />
-          Carbon Footprint CO2
+          탄소 배출량
+          </div>
+          <h4><CarbonDataViewer LineSelectedYear = {LineSelectedYear} LineSetSelectedYear={setLineSelectedYear}/></h4>
         </S.BottomTitle>
-        <LineChart />
+        <LineChart carbonData = {carbonData} LineSelectedYear = {LineSelectedYear}/>
       </S.DashboardBottom>
     </S.DashboardWrapper>
   );
@@ -220,9 +230,24 @@ const S = {
   MiddleTitle: styled.div`
     display: flex;
     justify-content: space-between;
-    width: 90%;
+    width: 100%; 
     font-size: 23px;
-    font-weight: 700px;
+    font-weight: 700;
+
+    div:first-child {
+      display: flex;
+      align-items: center;
+      gap: 0.7vw;
+
+      p {
+        white-space: nowrap;
+      }
+    }
+
+    h4 {
+      width:100%;
+      font-size: 18px;
+    }
   `,
   DashboardBottom: styled.div`
     width: 100%;
@@ -231,10 +256,15 @@ const S = {
   `,
   BottomTitle: styled.div`
     display: flex;
-    justify-content: start;
-    width: 90%;
+    justify-content: space-between;
+    width: 100%;
     font-size: 23px;
     font-weight: 700px;
     gap: 0.7vw;
+
+    h4 {
+      width: 20%;
+      font-size: 18px;
+    }
   `,
 };

--- a/src/components/dashboard/StyledDashboard.tsx
+++ b/src/components/dashboard/StyledDashboard.tsx
@@ -12,8 +12,28 @@ import calendar from '@/assets/dashboard/calendar.svg';
 import BarLineChart from './chart/BarLineChart';
 import CircleChart from './chart/CircleChart';
 import LineChart from './chart/LineChart';
+import type { CarbonAnalysisResult } from '@/types/types';
+import { useState } from 'react';
 
-const StyledDashboard = () => {
+type StyledDashboardProps = {
+  carbonData: any; // 실제 type으로 변경 필요
+  analyzeCarbonData: CarbonAnalysisResult | undefined;
+  setSelectedYear: React.Dispatch<React.SetStateAction<string>>;
+  setSelectedMonth: React.Dispatch<React.SetStateAction<string>>;
+}
+
+
+const StyledDashboard = ({ carbonData, analyzeCarbonData, setSelectedYear, setSelectedMonth }:StyledDashboardProps) => {
+
+  
+  const [selectedYear, setSelectedYedr] = useState('2024');
+  const locationKey = "0536_0009";
+  const yearKey = "2024";
+  const cData = carbonData?.[locationKey]?.[yearKey];
+  const aData = analyzeCarbonData?.[locationKey]?.analysis;
+  console.log('carbonData : ', carbonData)
+  console.log('analyzeCarbonData : ',analyzeCarbonData)
+  
   return (
     <S.DashboardWrapper>
       <S.DashboardHeader>
@@ -21,46 +41,46 @@ const StyledDashboard = () => {
           <S.HeaderItemTitle>
             <S.Row>
               <img src={firstImg} alt="firstImg" />
-              Overall System
+              연간 총 전기 사용량
               <br />
-              Efficiency
+              {selectedYear}
             </S.Row>
           </S.HeaderItemTitle>
-          <S.HeaderItemNumber>70%</S.HeaderItemNumber>
+          <S.HeaderItemNumber>{Math.floor(aData?.totalElectricity ?? 0).toLocaleString()}Wh</S.HeaderItemNumber>
         </S.DashboardHeaderItem>
         <S.DashboardHeaderItem>
           <S.HeaderItemTitle>
             <S.Row>
               <img src={secondImg} alt="secondImg" />
-              Renewable Energy
+              월 평균 전기 사용량
               <br />
               Utillization
             </S.Row>
           </S.HeaderItemTitle>
-          <S.HeaderItemNumber>70%</S.HeaderItemNumber>
+          <S.HeaderItemNumber>{Math.floor(aData?.avgElectricity ?? 0).toLocaleString()}Wh</S.HeaderItemNumber>
         </S.DashboardHeaderItem>
         <S.DashboardHeaderItem>
           <S.HeaderItemTitle>
             <S.Row>
               <img src={thirdImg} alt="thirdImg" />
-              Carbon Emmision
+              연간 총 탄소 배출량
               <br />
-              Reduction
+              {selectedYear}
             </S.Row>
           </S.HeaderItemTitle>
-          <S.HeaderItemNumber>40%</S.HeaderItemNumber>
+          <S.HeaderItemNumber>{Math.floor(aData?.totalCarbon ?? 0).toLocaleString()}</S.HeaderItemNumber>
         </S.DashboardHeaderItem>
         <S.DashboardHeaderItem>
           <S.HeaderItemTitle>
             <S.Row>
               <img src={fourthImg} alt="fourthImg" />
-              Energy Cost
-              <br /> Savings
+              월 평균 탄소 배출량
+              <br />
             </S.Row>
           </S.HeaderItemTitle>
           <S.HeaderItemNumber>
             <S.Row>
-              <p>150</p>
+              <p>{Math.floor(aData?.avgCarbon ?? 0).toLocaleString()}</p>
               <span>
                 metric tons
                 <br />
@@ -73,14 +93,14 @@ const StyledDashboard = () => {
           <S.HeaderItemTitle>
             <S.Row>
               <img src={fifthImg} alt="fifthImg" />
-              Overall System
+              {selectedYear} 최대 월별 
               <br />
-              Carbon Footprint
+              탄소 배출량
             </S.Row>
           </S.HeaderItemTitle>
           <S.HeaderItemNumber>
             <S.Row>
-              <p>150</p>
+              <p>{Math.floor(aData?.maxCarbon ?? 0).toLocaleString()}</p>
               <span>
                 metric tons
                 <br />
@@ -88,6 +108,17 @@ const StyledDashboard = () => {
               </span>
             </S.Row>
           </S.HeaderItemNumber>
+        </S.DashboardHeaderItem>
+        <S.DashboardHeaderItem>
+          <S.HeaderItemTitle>
+            <S.Row>
+              <img src={secondImg} alt="secondImg" />
+              {selectedYear} 최소 월별
+              <br />
+              탄소 배출량
+            </S.Row>
+          </S.HeaderItemTitle>
+          <S.HeaderItemNumber>{Math.floor(aData?.minCarbon ?? 0).toLocaleString()}</S.HeaderItemNumber>
         </S.DashboardHeaderItem>
       </S.DashboardHeader>
       <S.DashboardMiddle>

--- a/src/components/dashboard/StyledDashboard.tsx
+++ b/src/components/dashboard/StyledDashboard.tsx
@@ -15,6 +15,7 @@ import LineChart from './chart/LineChart';
 import type { CarbonAnalysisResult } from '@/types/types';
 import { CarbonDataViewer } from './CarbonDataViewer';
 import { EnergyCarbonDataViewer } from './EnergyCarbonDataViewer';
+import { useState } from 'react';
 
 type StyledDashboardProps = {   
   carbonData: any; // 실제 type으로 변경 필요   
@@ -35,10 +36,31 @@ const StyledDashboard = ({ carbonData, analyzeCarbonData, selectedYear,
  }:StyledDashboardProps) => {
   const locationKey = "0536_0009";
   const aData = analyzeCarbonData?.[locationKey]?.analysis;
-  //const [selectedBunji, setSelectedBunji] = useState("0536_0009");
+  const [selectedBunji, setSelectedBunji] = useState("0536_0009");
+
   
   return (
+
+    
     <S.DashboardWrapper>
+      {/* <select 
+        value={selectedMonth} 
+        onChange={(e) => setSelectedMonth(e.target.value)}
+      >
+      {Object.keys(carbonData?.carbonData?.[selectedBunji]?.[selectedYear] || {}).map(month => (
+        <option key={month} value={month}>{month}</option>
+      ))}
+
+      </select> */}
+
+      {/* <select 
+        value={selectedYear} 
+        onChange={(e) => setSelectedYear(e.target.value)}
+      >
+        {carbonData[selectedBunji] && Object.keys(carbonData[selectedBunji]).map(year => (
+          <option key={year} value={year}>{year}</option>
+        ))}
+      </select> */}
       <S.DashboardHeader>
         <S.DashboardHeaderItem>
           <S.HeaderItemTitle>
@@ -136,7 +158,7 @@ const StyledDashboard = ({ carbonData, analyzeCarbonData, selectedYear,
             <h4><EnergyCarbonDataViewer setBarSelectedYear={setBarSelectedYear} BarSelectedYear={BarSelectedYear}/></h4>
           <div style={{ display: 'flex', gap: '0.7vw' }}>
             <img src={calendar} alt="calendar" />
-            우리 동네에서 내 탄소 점유율
+            우리 동네에서 5월 나의 탄소 점유율
           </div>
         </S.MiddleTitle>
         <S.Row>

--- a/src/components/dashboard/chart/CircleChart.tsx
+++ b/src/components/dashboard/chart/CircleChart.tsx
@@ -21,13 +21,13 @@ const CircleChart = () => {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const data = [170, 24.6];
+    const data = [238, 35];
     const total = data.reduce((sum, v) => sum + v, 0);
 
     chartInstance.current = new Chart(ctx, {
       type: 'pie',
       data: {
-        labels: ['Main Power', 'Green Energy'],
+        labels: ['강남구 탄소 배출량', '내 탄소 배출량'],
         datasets: [
           {
             data,
@@ -97,19 +97,19 @@ const CircleChart = () => {
       >
         <LegendItem
           color="#FFA048"
-          label="Main Power"
-          description="238 THB"
+          label="강남구 탄소 배출량"
+          description="238"
           bgColor="rgba(255, 160, 72, 0.1)"
         />
         <LegendItem
           color="#3BA881"
-          label="Green Energy"
-          description="90 THB"
+          label="나의 탄소 배출량"
+          description="35"
           bgColor="rgba(74, 184, 118, 0.1)"
         />
       </div>
       <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 20 }}>
-        Total: 194.6
+        Total: 273
       </div>
       <div
         style={{
@@ -130,7 +130,7 @@ const CircleChart = () => {
             textAlign: 'center',
           }}
         >
-          (단위: 구)
+          (5월 기준, 단위 : tCO2eq)
         </div>
       </div>
     </div>

--- a/src/components/dashboard/chart/CircleChart.tsx
+++ b/src/components/dashboard/chart/CircleChart.tsx
@@ -47,7 +47,7 @@ const CircleChart = () => {
               label: (ctx) => `${ctx.label}: ${ctx.parsed}`,
             },
           },
-          // @ts-error
+
           datalabels: {
             formatter: (value: number) => {
               const percent = (value / total) * 100;
@@ -118,9 +118,20 @@ const CircleChart = () => {
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
+          flexDirection: 'column',
         }}
       >
         <canvas ref={canvasRef} />
+        <div
+          style={{
+            marginTop: 10,
+            fontSize: 13,
+            color: '#666',
+            textAlign: 'center',
+          }}
+        >
+          (단위: 구)
+        </div>
       </div>
     </div>
   );
@@ -132,6 +143,7 @@ type LegendItemProps = {
   description?: string;
   bgColor: string;
 };
+
 const LegendItem: React.FC<LegendItemProps> = ({
   color,
   label,

--- a/src/components/dashboard/chart/LineChart.tsx
+++ b/src/components/dashboard/chart/LineChart.tsx
@@ -21,13 +21,21 @@ Chart.register(
   Legend
 );
 
-const LineChart = () => {
+type LineChartProps = {
+  carbonData: any;
+  LineSelectedYear: string;
+}
+
+const LineChart = ({carbonData, LineSelectedYear} : LineChartProps) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const chartInstance = useRef<ChartType | null>(null);
 
+  const locationKey = "0536_0009";
+  const cData = carbonData?.[locationKey]?.[LineSelectedYear];
+
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    if (!canvas || !cData) return;
 
     const existingChart = Chart.getChart(canvas);
     if (existingChart) existingChart.destroy();
@@ -35,32 +43,37 @@ const LineChart = () => {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const years = [
-      '2015',
-      '2016',
-      '2017',
-      '2018',
-      '2019',
-      '2020',
-      '2021',
-      '2022',
-      '2023',
-    ];
-    const dataValues = [10, 15, 20, 22, 25, 27, 28, 29, 30];
+    // 월별 데이터 처리
+    const months = Object.keys(cData).sort(); // 월을 정렬 (01, 02, 03, ...)
+    
+    // 각 월의 탄소 배출량 데이터 추출
+    const carbonEmissions = months.map(month => {
+      const monthData = cData[month];
+      return monthData?.carbon_emission_kgCO2eq || 0;
+    });
+
+    const monthLabels = months.map(month => `${parseInt(month)}월`);
+
+   
+    const maxEmission = Math.max(...carbonEmissions);
+    const yAxisMax = Math.ceil(maxEmission / 1000) * 1000; // 1000 단위로 반올림
 
     chartInstance.current = new Chart(ctx, {
       type: 'line',
       data: {
-        labels: years,
+        labels: monthLabels,
         datasets: [
           {
-            label: 'Main Power',
-            data: dataValues,
+            label: '탄소 배출량 (kgCO2eq)',
+            data: carbonEmissions,
             borderColor: '#4AB876',
-            backgroundColor: 'rgba(99, 160, 2, 0.49)',
+            backgroundColor: 'rgba(74, 184, 118, 0.1)',
             tension: 0.4,
             fill: true,
             pointRadius: 4,
+            pointBackgroundColor: '#4AB876',
+            pointBorderColor: '#ffffff',
+            pointBorderWidth: 2,
           },
         ],
       },
@@ -68,8 +81,19 @@ const LineChart = () => {
         responsive: true,
         maintainAspectRatio: false,
         plugins: {
-          legend: { display: false },
-          tooltip: { mode: 'index', intersect: false },
+          legend: { 
+            display: true,
+            position: 'top',
+          },
+          tooltip: { 
+            mode: 'index', 
+            intersect: false,
+            callbacks: {
+              label: function(context) {
+                return `${context.dataset.label}: ${context.parsed.y.toLocaleString()} kgCO2eq`;
+              }
+            }
+          },
         },
         interaction: {
           mode: 'nearest',
@@ -79,14 +103,21 @@ const LineChart = () => {
         scales: {
           x: {
             display: true,
+            title: {
+              display: true,
+              text: '월'
+            }
           },
           y: {
             display: true,
             min: 0,
-            max: 30,
+            max: yAxisMax,
+            title: {
+              display: false,
+              text: '탄소 배출량 (kgCO2eq)'
+            },
             ticks: {
-              stepSize: 10,
-              callback: (value) => `${value} kg`,
+              callback: (value) => `${(value as number).toLocaleString()}`,
             },
           },
         },
@@ -97,7 +128,7 @@ const LineChart = () => {
       chartInstance.current?.destroy();
       chartInstance.current = null;
     };
-  }, []);
+  }, [cData]);
 
   return (
     <div

--- a/src/components/mypage/StyledMy.tsx
+++ b/src/components/mypage/StyledMy.tsx
@@ -1,4 +1,4 @@
-import type { UserInfoType } from '@/api/api';
+import type { UserInfoType } from '@/api/auth/api';
 import Button from '@/components/common/button/Button';
 import Input from '@/components/common/input/Input';
 import { colors } from '@/styles';

--- a/src/hooks/auth/auth.ts
+++ b/src/hooks/auth/auth.ts
@@ -1,4 +1,4 @@
-import { getUserDB, getUserId, type UserType } from '@/api/api';
+import { getUserDB, getUserId, type UserType } from '@/api/auth/api';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 export const useUserStore = () => {

--- a/src/hooks/dashboard/dashboard.ts
+++ b/src/hooks/dashboard/dashboard.ts
@@ -1,0 +1,55 @@
+import { getAvailableDates, getCarbonDataByDate, getLatestCarbonData } from "@/api/dashboard/api";
+import { useEffect, useState } from "react";
+
+export const useCarbonData = (address: string) => {
+  const [latestData, setLatestData] = useState<any>(null);
+  const [selectedData, setSelectedData] = useState<any>(null);
+  const [availableDates, setAvailableDates] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  
+  // 초기 데이터 로드 (가장 최근 데이터)
+  useEffect(() => {
+    const loadInitialData = async () => {
+      setLoading(true);
+      try {
+        const [latest, dates] = await Promise.all([
+          getLatestCarbonData(address),
+          getAvailableDates(address)
+        ]);
+        
+        setLatestData(latest);
+        setAvailableDates(dates);
+        setSelectedData(latest);
+      } catch (error) {
+        console.error('Error loading initial data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    
+    if (address) {
+      loadInitialData();
+    }
+  }, [address]);
+  
+  // 특정 날짜 데이터 선택
+  const selectDate = async (year: string, month?: string) => {
+    setLoading(true);
+    try {
+      const data = await getCarbonDataByDate(address, year, month);
+      setSelectedData(data);
+    } catch (error) {
+      console.error('Error loading selected data:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+  
+  return {
+    latestData,
+    selectedData,
+    availableDates,
+    loading,
+    selectDate
+  };
+};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -6,3 +6,17 @@ export type AuthContextType = {
   userId: string | undefined;
   setUserId: (id: string | undefined) => void;
 };
+
+export type CarbonAnalysisResult = {
+  [bunji: string]: {
+    [year: string]: {
+      totalCarbon: number;
+      totalElectricity: number;
+      avgCarbon: number;
+      avgElectricity: number;
+      maxCarbon: number;
+      minCarbon: number;
+      monthCount: number;
+    };
+  };
+}


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 [#29]

## 🔎 작업 내용

- [x] 전기 사용량
- [x] 탄소 배출량 
- [x] 2022 ~ 2025까지의 데이터를 그래프로 알맞게 출력

## 💾 이미지 첨부

![image](https://github.com/user-attachments/assets/a007cb57-afa9-43ed-80b2-b212e5e851e8)


## 🔧 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요
